### PR TITLE
AssignCodewords fix double overflow of marker[1]

### DIFF
--- a/vorbis/codebook.go
+++ b/vorbis/codebook.go
@@ -125,8 +125,8 @@ func (book *Codebook) AssignCodewords() {
           marker[1]++
         } else {
           marker[j] = marker[j-1] << 1
-          break
         }
+        break
       }
       marker[j]++
     }


### PR DESCRIPTION
If you do not have the break where I put it, `marker[1]` would get executed twice. So from `marker[1] == 1`, it would first become `marker[1] == 2` (10_b) and then `marker[1] == 3` (11_b), which is probably not intended. This might not matter, as it only happens once the leaf is overful, i.e. fully specified, but it would allow for a simpler underspecify check at the end (which currently is missing).